### PR TITLE
Дата окончания сервисного плана теперь может быть пустой

### DIFF
--- a/shared/homeless/app/Resources/views/form/fields.html.twig
+++ b/shared/homeless/app/Resources/views/form/fields.html.twig
@@ -99,7 +99,7 @@
     {% set title = 'Срок действия неизвестен' %}
     {% set color = 'black' %}
 
-    {% if value is not null %}
+    {% if value is not null and value != '' %}
         {% if value < 3 %}
             {% set title = 'Краткосрочный' %}
             {% set color = 'green' %}

--- a/shared/homeless/src/AppBundle/Admin/ContractAdmin.php
+++ b/shared/homeless/src/AppBundle/Admin/ContractAdmin.php
@@ -72,7 +72,7 @@ class ContractAdmin extends BaseAdmin
                 'dp_default_date' => (new \DateTime())->format('Y-m-d'),
                 'format' => 'dd.MM.yyyy',
                 'label' => 'Дата окончания',
-                'required' => true,
+                'required' => false,
             ])
             ->add('comment', null, [
                 'label' => 'Комментарий',


### PR DESCRIPTION
Ещё немного подпилил виджет долгосрочности плана, чтобы при отсутствии даты окончания план не считался краткосрочным.
TODO: более правильно делать типизацию значения duration на бэкенде