### PR TITLE
Update Nginx config according to deprecation warning

### DIFF
--- a/docker/app/files/nginx/templates/https/default.conf.tpl
+++ b/docker/app/files/nginx/templates/https/default.conf.tpl
@@ -21,8 +21,9 @@ server {
 }
 
 server {
-    listen 443 default_server ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 default_server ssl;
+    listen [::]:443 ssl;
+    http2 on;
 
     server_name ${DOMAIN};
 


### PR DESCRIPTION
https://www.f5.com/company/blog/nginx/nginx-plus-r30-released
The listen … http2 directive has been deprecated in NGINX 1.25.1.

Change this:
```
listen 443 ssl http2;
```
To this:

```
listen 443 ssl;
http2 on;
```

